### PR TITLE
36 feat 포트폴리오 ai 개선진단 api 하루사용량 제한 추가 및 데이터 캐싱 포트폴리오 공유 api 응답 수정

### DIFF
--- a/devlog/src/main/java/com/devlog/devlog/auth/controller/GitAnalyzeController.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/controller/GitAnalyzeController.java
@@ -29,31 +29,35 @@ public class GitAnalyzeController {
     private final int MAX_REQUEST_LIMIT = 5;
 
     @PostMapping("/analyze")
-    public ResponseEntity<ApiResponse<GitAnalyzeResponse>> analyzeRepo(@RequestBody GitAnalyzeRequest request,
+    public ResponseEntity<ApiResponse<GitAnalyzeResponse>> analyzeRepo(
+            @RequestBody GitAnalyzeRequest request,
             Authentication authentication) {
 
         String userEmail = authentication.getName();
         String limitKey = RATE_LIMIT_PREFIX + userEmail;
 
-       Long count = redisTemplate.opsForValue().increment(limitKey);
-       if(count == 1){
-           redisTemplate.expire(limitKey, Duration.ofDays(5));
-       }
-        if (count >= MAX_REQUEST_LIMIT)
-            throw new BusinessException(ErrorCode.API_RATE_LIMIT_EXCEEDED);
+        Long count = redisTemplate.opsForValue().increment(limitKey);
 
-        // 핵심 로직은 service로 분리해서 캐싱
-        GitAnalyzeResponse response = gitAnalyzeService.analyze(request.getGitUrl());
-
-        Long newCount = redisTemplate.opsForValue().increment(limitKey);
-        if (newCount != null && newCount == 1L) {
-            redisTemplate.expire(limitKey, Duration.ofDays(1));
+        if (count != null && count == 1L) {
+            redisTemplate.expire(limitKey, Duration.ofDays(5));
         }
 
-        int remaining = MAX_REQUEST_LIMIT - newCount.intValue();
+        if (count != null && count > MAX_REQUEST_LIMIT) {
+            throw new BusinessException(ErrorCode.API_RATE_LIMIT_EXCEEDED);
+        }
+
+        GitAnalyzeResponse response =
+                gitAnalyzeService.analyze(request.getGitUrl());
+
+        int remaining = MAX_REQUEST_LIMIT - count.intValue();
+
         return ResponseEntity.ok()
-                .header("X-RateLimit-Limit", String.valueOf(MAX_REQUEST_LIMIT))
-                .header("X-RateLimit-Remaining", String.valueOf(remaining))
-                .body(ApiResponse.success("프로젝트 분석이 완료 되었습니다.", response));
+                .header("X-RateLimit-Limit",
+                        String.valueOf(MAX_REQUEST_LIMIT))
+                .header("X-RateLimit-Remaining",
+                        String.valueOf(remaining))
+                .body(ApiResponse.success(
+                        "프로젝트 분석이 완료 되었습니다.",
+                        response));
     }
 }

--- a/devlog/src/main/java/com/devlog/devlog/auth/controller/GitAnalyzeController.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/controller/GitAnalyzeController.java
@@ -35,9 +35,10 @@ public class GitAnalyzeController {
         String userEmail = authentication.getName();
         String limitKey = RATE_LIMIT_PREFIX + userEmail;
 
-        String countStr = redisTemplate.opsForValue().get(limitKey);
-        int count = countStr != null ? Integer.parseInt(countStr) : 0;
-
+       Long count = redisTemplate.opsForValue().increment(limitKey);
+       if(count == 1){
+           redisTemplate.expire(limitKey, Duration.ofDays(5));
+       }
         if (count >= MAX_REQUEST_LIMIT)
             throw new BusinessException(ErrorCode.API_RATE_LIMIT_EXCEEDED);
 

--- a/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
@@ -81,21 +81,20 @@ public class PortfolioController {
                         @RequestBody AiFeedbackRequest request) {
                 String userEmail = authentication.getName();
 
-                rateLimitService.validateLimit(
+                UsageLimitResponse usageLimit = rateLimitService.checkAndIncrement(
                                 RATE_LIMIT_PREFIX,
                                 userEmail,
                                 MAX_REQUEST_LIMIT,
                                 ErrorCode.AI_FEEDBACK_DAILY_LIMIT_EXCEEDED);
 
-                AiFeedbackResponse response = portfolioService.createAiFeedback(userEmail, request);
-
-                UsageLimitResponse usageLimit = rateLimitService.consume(
-                                RATE_LIMIT_PREFIX,
-                                userEmail,
-                                MAX_REQUEST_LIMIT);
-                response.setUsageLimit(usageLimit);
-
-                return ResponseEntity.ok(ApiResponse.success("AI 진단 성공", response));
+                try {
+                        AiFeedbackResponse response = portfolioService.createAiFeedback(userEmail, request);
+                        response.setUsageLimit(usageLimit);
+                        return ResponseEntity.ok(ApiResponse.success("AI 진단 성공", response));
+                } catch (Exception e) {
+                        rateLimitService.rollback(RATE_LIMIT_PREFIX, userEmail);
+                        throw e;
+                }
         }
 
         @PostMapping(value = "/portfolios/{portfolioId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
@@ -8,19 +8,28 @@ import com.devlog.devlog.auth.dto.portfolio.response.*;
 
 import com.devlog.devlog.auth.service.PortfolioService;
 import com.devlog.devlog.global.common.ApiResponse;
+import com.devlog.devlog.global.exception.BusinessException;
+import com.devlog.devlog.global.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class PortfolioController {
     private final PortfolioService portfolioService;
+    private static final String RATE_LIMIT_PREFIX = "portfolio_feedback_limit:";
+    private final int MAX_REQUEST_LIMIT = 5;
+    private final StringRedisTemplate redisTemplate;
+
     @PostMapping("/portfolios")
     public ResponseEntity<ApiResponse<PortfolioResponse>> createPortfolio(
             Authentication authentication,
@@ -29,6 +38,7 @@ public class PortfolioController {
         PortfolioResponse res = portfolioService.createPortfolio(authentication.getName(), request);
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 저장 성공", res));
     }
+
     @GetMapping("/portfolios/{portfolioId}")
     public ResponseEntity<ApiResponse<PortfolioDetailResponse>> getPortfolio(
             Authentication authentication,
@@ -37,6 +47,7 @@ public class PortfolioController {
         PortfolioDetailResponse res = portfolioService.getPortfolio(authentication.getName(), portfolioId);
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 조회 성공", res));
     }
+
     @GetMapping("/projects/{projectId}/portfolio")
     public ResponseEntity<ApiResponse<ProjectPortfolioResponse>> getProjectPortfolio(
             Authentication authentication,
@@ -45,6 +56,7 @@ public class PortfolioController {
         ProjectPortfolioResponse res = portfolioService.getProjectPortfolio(authentication.getName(), projectId);
         return ResponseEntity.ok(ApiResponse.success("프로젝트 포트폴리오 조회 성공", res));
     }
+
     @PatchMapping("/portfolios/{portfolioID}")
     public ResponseEntity<ApiResponse<PortfolioResponse>> updatePortfolio(
             Authentication authentication,
@@ -54,6 +66,7 @@ public class PortfolioController {
         PortfolioResponse res = portfolioService.updatePortfolio(authentication.getName(), portfolioID, request);
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 수정 성공", res));
     }
+
     @DeleteMapping("/portfolios/{portfolioId}")
     public ResponseEntity<ApiResponse<DeletePortfolioResponse>> deletePortfolio(
             Authentication authentication,
@@ -62,14 +75,33 @@ public class PortfolioController {
         DeletePortfolioResponse res = portfolioService.deletePortfolio(authentication.getName(), portfolioId);
         return ResponseEntity.ok(ApiResponse.success("포트폴리오 삭제 성공", res));
     }
+
     @PostMapping("/portfolios/ai-feedback")
     public ResponseEntity<ApiResponse<AiFeedbackResponse>> createAiFeedback(
             Authentication authentication,
             @RequestBody AiFeedbackRequest request
     ){
-        AiFeedbackResponse res = portfolioService.createAiFeedback(authentication.getName(), request);
+        String userEmail = authentication.getName();
+        String limitKey = RATE_LIMIT_PREFIX + userEmail;
+
+        Long count = redisTemplate.opsForValue().increment(limitKey);
+
+        if (count != null && count == 1L) {
+            redisTemplate.expire(limitKey, Duration.ofDays(5));
+        }
+
+        if (count != null && count > MAX_REQUEST_LIMIT) {
+            throw new BusinessException(ErrorCode.API_RATE_LIMIT_EXCEEDED);
+        }
+
+        AiFeedbackResponse res = portfolioService.createAiFeedback(userEmail, request);
+        Long newCount = redisTemplate.opsForValue().increment(limitKey);
+        if (newCount != null && newCount == 1L) {
+            redisTemplate.expire(limitKey, Duration.ofDays(1));
+        }
         return ResponseEntity.ok(ApiResponse.success("AI 진단 성공", res));
     }
+
     @PostMapping(
             value = "/portfolios/{portfolioId}/pdf",
             produces = MediaType.APPLICATION_PDF_VALUE
@@ -90,6 +122,7 @@ public class PortfolioController {
                 "attachment; filename=\"" + pdf.getFileName() + "\""
         ).contentType(MediaType.APPLICATION_PDF).body(pdf.getPdfBytes());
     }
+
     @PostMapping("/portfolios/{portfolioId}/share")
     public ResponseEntity<ApiResponse<SharePortfolioResponse>> sharePortfolio(
             Authentication authentication,
@@ -99,6 +132,7 @@ public class PortfolioController {
         SharePortfolioResponse res = portfolioService.sharePortfolio(authentication.getName(), portfolioId, request);
         return ResponseEntity.ok(ApiResponse.success("공유 링크 생성 성공", res));
     }
+
     @GetMapping("/portfolios/share/{shareToken}")
     public ResponseEntity<ApiResponse<SharedPortfolioResponse>> getSharePortfolio(@PathVariable String shareToken) {
         SharedPortfolioResponse res = portfolioService.getSharePortfolio(shareToken);

--- a/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/controller/PortfolioController.java
@@ -8,6 +8,8 @@ import com.devlog.devlog.auth.dto.portfolio.response.*;
 
 import com.devlog.devlog.auth.service.PortfolioService;
 import com.devlog.devlog.global.common.ApiResponse;
+import com.devlog.devlog.global.common.RateLimitService;
+import com.devlog.devlog.global.common.UsageLimitResponse;
 import com.devlog.devlog.global.exception.BusinessException;
 import com.devlog.devlog.global.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,118 +27,106 @@ import java.time.Duration;
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class PortfolioController {
-    private final PortfolioService portfolioService;
-    private static final String RATE_LIMIT_PREFIX = "portfolio_feedback_limit:";
-    private final int MAX_REQUEST_LIMIT = 5;
-    private final StringRedisTemplate redisTemplate;
+        private final PortfolioService portfolioService;
+        private static final String RATE_LIMIT_PREFIX = "portfolio_feedback_limit:";
+        private final int MAX_REQUEST_LIMIT = 5;
+        private final RateLimitService rateLimitService;
 
-    @PostMapping("/portfolios")
-    public ResponseEntity<ApiResponse<PortfolioResponse>> createPortfolio(
-            Authentication authentication,
-            @RequestBody CreatePortfolioRequest request
-            ) throws JsonProcessingException {
-        PortfolioResponse res = portfolioService.createPortfolio(authentication.getName(), request);
-        return ResponseEntity.ok(ApiResponse.success("포트폴리오 저장 성공", res));
-    }
-
-    @GetMapping("/portfolios/{portfolioId}")
-    public ResponseEntity<ApiResponse<PortfolioDetailResponse>> getPortfolio(
-            Authentication authentication,
-            @PathVariable Long portfolioId
-    ) {
-        PortfolioDetailResponse res = portfolioService.getPortfolio(authentication.getName(), portfolioId);
-        return ResponseEntity.ok(ApiResponse.success("포트폴리오 조회 성공", res));
-    }
-
-    @GetMapping("/projects/{projectId}/portfolio")
-    public ResponseEntity<ApiResponse<ProjectPortfolioResponse>> getProjectPortfolio(
-            Authentication authentication,
-            @PathVariable Long projectId
-    ){
-        ProjectPortfolioResponse res = portfolioService.getProjectPortfolio(authentication.getName(), projectId);
-        return ResponseEntity.ok(ApiResponse.success("프로젝트 포트폴리오 조회 성공", res));
-    }
-
-    @PatchMapping("/portfolios/{portfolioID}")
-    public ResponseEntity<ApiResponse<PortfolioResponse>> updatePortfolio(
-            Authentication authentication,
-            @PathVariable Long portfolioID,
-            @RequestBody CreatePortfolioRequest request
-    ) throws JsonProcessingException {
-        PortfolioResponse res = portfolioService.updatePortfolio(authentication.getName(), portfolioID, request);
-        return ResponseEntity.ok(ApiResponse.success("포트폴리오 수정 성공", res));
-    }
-
-    @DeleteMapping("/portfolios/{portfolioId}")
-    public ResponseEntity<ApiResponse<DeletePortfolioResponse>> deletePortfolio(
-            Authentication authentication,
-            @PathVariable Long portfolioId
-    ){
-        DeletePortfolioResponse res = portfolioService.deletePortfolio(authentication.getName(), portfolioId);
-        return ResponseEntity.ok(ApiResponse.success("포트폴리오 삭제 성공", res));
-    }
-
-    @PostMapping("/portfolios/ai-feedback")
-    public ResponseEntity<ApiResponse<AiFeedbackResponse>> createAiFeedback(
-            Authentication authentication,
-            @RequestBody AiFeedbackRequest request
-    ){
-        String userEmail = authentication.getName();
-        String limitKey = RATE_LIMIT_PREFIX + userEmail;
-
-        Long count = redisTemplate.opsForValue().increment(limitKey);
-
-        if (count != null && count == 1L) {
-            redisTemplate.expire(limitKey, Duration.ofDays(5));
+        @PostMapping("/portfolios")
+        public ResponseEntity<ApiResponse<PortfolioResponse>> createPortfolio(
+                        Authentication authentication,
+                        @RequestBody CreatePortfolioRequest request) throws JsonProcessingException {
+                PortfolioResponse res = portfolioService.createPortfolio(authentication.getName(), request);
+                return ResponseEntity.ok(ApiResponse.success("포트폴리오 저장 성공", res));
         }
 
-        if (count != null && count > MAX_REQUEST_LIMIT) {
-            throw new BusinessException(ErrorCode.API_RATE_LIMIT_EXCEEDED);
+        @GetMapping("/portfolios/{portfolioId}")
+        public ResponseEntity<ApiResponse<PortfolioDetailResponse>> getPortfolio(
+                        Authentication authentication,
+                        @PathVariable Long portfolioId) {
+                PortfolioDetailResponse res = portfolioService.getPortfolio(authentication.getName(), portfolioId);
+                return ResponseEntity.ok(ApiResponse.success("포트폴리오 조회 성공", res));
         }
 
-        AiFeedbackResponse res = portfolioService.createAiFeedback(userEmail, request);
-        Long newCount = redisTemplate.opsForValue().increment(limitKey);
-        if (newCount != null && newCount == 1L) {
-            redisTemplate.expire(limitKey, Duration.ofDays(1));
+        @GetMapping("/projects/{projectId}/portfolio")
+        public ResponseEntity<ApiResponse<ProjectPortfolioResponse>> getProjectPortfolio(
+                        Authentication authentication,
+                        @PathVariable Long projectId) {
+                ProjectPortfolioResponse res = portfolioService.getProjectPortfolio(authentication.getName(),
+                                projectId);
+                return ResponseEntity.ok(ApiResponse.success("프로젝트 포트폴리오 조회 성공", res));
         }
-        return ResponseEntity.ok(ApiResponse.success("AI 진단 성공", res));
-    }
 
-    @PostMapping(
-            value = "/portfolios/{portfolioId}/pdf",
-            produces = MediaType.APPLICATION_PDF_VALUE
-    )
-    public ResponseEntity<byte[]> downloadPdf(
-            Authentication authentication,
-            @PathVariable Long portfolioId,
-            @RequestBody PortfolioPdfRequest request
-    ) throws JsonProcessingException {
-        PdfDownloadResponse pdf =
-                portfolioService.generatePdf(
-                        authentication.getName(),
-                        portfolioId,
-                        request
-                );
-        return ResponseEntity.ok().header(
-                HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=\"" + pdf.getFileName() + "\""
-        ).contentType(MediaType.APPLICATION_PDF).body(pdf.getPdfBytes());
-    }
+        @PatchMapping("/portfolios/{portfolioID}")
+        public ResponseEntity<ApiResponse<PortfolioResponse>> updatePortfolio(
+                        Authentication authentication,
+                        @PathVariable Long portfolioID,
+                        @RequestBody CreatePortfolioRequest request) throws JsonProcessingException {
+                PortfolioResponse res = portfolioService.updatePortfolio(authentication.getName(), portfolioID,
+                                request);
+                return ResponseEntity.ok(ApiResponse.success("포트폴리오 수정 성공", res));
+        }
 
-    @PostMapping("/portfolios/{portfolioId}/share")
-    public ResponseEntity<ApiResponse<SharePortfolioResponse>> sharePortfolio(
-            Authentication authentication,
-            @PathVariable Long portfolioId,
-            @RequestBody SharePortfolioRequest request
-    ){
-        SharePortfolioResponse res = portfolioService.sharePortfolio(authentication.getName(), portfolioId, request);
-        return ResponseEntity.ok(ApiResponse.success("공유 링크 생성 성공", res));
-    }
+        @DeleteMapping("/portfolios/{portfolioId}")
+        public ResponseEntity<ApiResponse<DeletePortfolioResponse>> deletePortfolio(
+                        Authentication authentication,
+                        @PathVariable Long portfolioId) {
+                DeletePortfolioResponse res = portfolioService.deletePortfolio(authentication.getName(), portfolioId);
+                return ResponseEntity.ok(ApiResponse.success("포트폴리오 삭제 성공", res));
+        }
 
-    @GetMapping("/portfolios/share/{shareToken}")
-    public ResponseEntity<ApiResponse<SharedPortfolioResponse>> getSharePortfolio(@PathVariable String shareToken) {
-        SharedPortfolioResponse res = portfolioService.getSharePortfolio(shareToken);
-        return ResponseEntity.ok(ApiResponse.success("공유 포트폴리오 조회 성공", res));
-    }
+        @PostMapping("/portfolios/ai-feedback")
+        public ResponseEntity<ApiResponse<AiFeedbackResponse>> createAiFeedback(
+                        Authentication authentication,
+                        @RequestBody AiFeedbackRequest request) {
+                String userEmail = authentication.getName();
+
+                rateLimitService.validateLimit(
+                                RATE_LIMIT_PREFIX,
+                                userEmail,
+                                MAX_REQUEST_LIMIT,
+                                ErrorCode.AI_FEEDBACK_DAILY_LIMIT_EXCEEDED);
+
+                AiFeedbackResponse response = portfolioService.createAiFeedback(userEmail, request);
+
+                UsageLimitResponse usageLimit = rateLimitService.consume(
+                                RATE_LIMIT_PREFIX,
+                                userEmail,
+                                MAX_REQUEST_LIMIT);
+                response.setUsageLimit(usageLimit);
+
+                return ResponseEntity.ok(ApiResponse.success("AI 진단 성공", response));
+        }
+
+        @PostMapping(value = "/portfolios/{portfolioId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+        public ResponseEntity<byte[]> downloadPdf(
+                        Authentication authentication,
+                        @PathVariable Long portfolioId,
+                        @RequestBody PortfolioPdfRequest request) throws JsonProcessingException {
+                PdfDownloadResponse pdf = portfolioService.generatePdf(
+                                authentication.getName(),
+                                portfolioId,
+                                request);
+                return ResponseEntity.ok().header(
+                                HttpHeaders.CONTENT_DISPOSITION,
+                                "attachment; filename=\"" + pdf.getFileName() + "\"")
+                                .contentType(MediaType.APPLICATION_PDF).body(pdf.getPdfBytes());
+        }
+
+        @PostMapping("/portfolios/{portfolioId}/share")
+        public ResponseEntity<ApiResponse<SharePortfolioResponse>> sharePortfolio(
+                        Authentication authentication,
+                        @PathVariable Long portfolioId,
+                        @RequestBody SharePortfolioRequest request) {
+                SharePortfolioResponse res = portfolioService.sharePortfolio(authentication.getName(), portfolioId,
+                                request);
+                return ResponseEntity.ok(ApiResponse.success("공유 링크 생성 성공", res));
+        }
+
+        @GetMapping("/portfolios/share/{shareToken}")
+        public ResponseEntity<ApiResponse<SharedPortfolioResponse>> getSharePortfolio(@PathVariable String shareToken) {
+                SharedPortfolioResponse res = portfolioService.getSharePortfolio(shareToken);
+                return ResponseEntity.ok(ApiResponse.success("공유 포트폴리오 조회 성공", res));
+        }
 
 }

--- a/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/request/AiFeedbackRequest.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/request/AiFeedbackRequest.java
@@ -16,6 +16,9 @@ public class AiFeedbackRequest {
     private Long projectId;
     private String overview;
     private String roles;
+    private String projectPeriod;
+    private String teamSize;
+    private String primaryRole;
     private List<String> techStack;
     private List<FeatureDTO> features;
     private List<TroubleshootDTO> troubleshoots;

--- a/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/response/AiFeedbackResponse.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/response/AiFeedbackResponse.java
@@ -1,14 +1,13 @@
 package com.devlog.devlog.auth.dto.portfolio.response;
 
 import com.devlog.devlog.auth.dto.portfolio.AutoCompletedFieldsDTO;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.devlog.devlog.global.common.UsageLimitResponse;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,4 +16,5 @@ public class AiFeedbackResponse {
     private List<String> missingSections;
     private List<String> suggestions;
     private AutoCompletedFieldsDTO autoCompletedFields;
+    private UsageLimitResponse usageLimit;
 }

--- a/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/response/SharedPortfolioResponse.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/dto/portfolio/response/SharedPortfolioResponse.java
@@ -18,6 +18,9 @@ import java.util.List;
 public class SharedPortfolioResponse {
     private Long id;
     private String projectName;
+    private String projectPeriod;
+    private String teamSize;
+    private String primaryRole;
     private String overview;
     private String roles;
     private List<String> techStack;

--- a/devlog/src/main/java/com/devlog/devlog/auth/service/GeminiService.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/service/GeminiService.java
@@ -32,12 +32,7 @@ public class GeminiService {
 
         private static final String GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
 
-        @Retryable(
-                retryFor = HttpServerErrorException.class,
-                noRetryFor = HttpClientErrorException.class,
-                maxAttempts = 3,
-                backoff = @Backoff(delay = 2000, multiplier = 2)
-        )
+        @Retryable(retryFor = HttpServerErrorException.class, noRetryFor = HttpClientErrorException.class, maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
         public String summarize(String readme, List<String> commits) {
                 String prompt = buildPrompt(readme, commits);
                 // Gemini API 요청 바디 구성
@@ -66,21 +61,13 @@ public class GeminiService {
                 return "";
         }
 
-        @Retryable(
-                retryFor = HttpServerErrorException.class,
-                noRetryFor = HttpClientErrorException.class,
-                maxAttempts = 3,
-                backoff = @Backoff(delay = 2000, multiplier = 2)
-        )
+        @Retryable(retryFor = HttpServerErrorException.class, noRetryFor = HttpClientErrorException.class, maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
         public AiFeedbackResponse PortfolioAiFeedback(AiFeedbackRequest request) {
                 String prompt = buildFeedbackPrompt(request);
                 Map<String, Object> requestBody = Map.of(
-                        "contents", List.of(
-                                Map.of("parts", List.of(
-                                        Map.of("text", prompt)
-                                ))
-                        )
-                );
+                                "contents", List.of(
+                                                Map.of("parts", List.of(
+                                                                Map.of("text", prompt)))));
                 HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(MediaType.APPLICATION_JSON);
                 headers.set("x-goog-api-key", apiKey);
@@ -88,20 +75,19 @@ public class GeminiService {
                 URI uri = URI.create(GEMINI_URL);
                 HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
                 ResponseEntity<JsonNode> response = restTemplate.exchange(
-                        uri, HttpMethod.POST, entity, JsonNode.class
-                );
+                                uri, HttpMethod.POST, entity, JsonNode.class);
                 if (response.getBody() != null) {
                         try {
                                 String jsonText = response.getBody()
-                                        .get("candidates").get(0)
-                                        .get("content")
-                                        .get("parts").get(0)
-                                        .get("text").asText();
+                                                .get("candidates").get(0)
+                                                .get("content")
+                                                .get("parts").get(0)
+                                                .get("text").asText();
                                 // 간혹 AI가 텍스트 앞뒤로 ```json ... ``` 을 붙이는 경우가 있으므로 방어 코드 작성
                                 jsonText = jsonText
-                                        .replaceAll("```json", "")
-                                        .replaceAll("```", "")
-                                        .trim();
+                                                .replaceAll("```json", "")
+                                                .replaceAll("```", "")
+                                                .trim();
 
                                 // 2. 받아온 JSON 텍스트를 미리 설계한 DTO 객체 구조로 역직렬화(Deserialization)
                                 ObjectMapper objectMapper = new ObjectMapper();
@@ -148,40 +134,44 @@ public class GeminiService {
                 }
 
                 return """
-                        다음은 사용자가 입력 중인 포트폴리오 데이터입니다.
-                        
-                        [포트폴리오 데이터]
-                        %s
-                        
-                        [진단 가이드라인]
-                        1. 위 데이터를 기반으로 포트폴리오의 완성도를 진단하고 개선 사항을 도출하세요.
-                        2. 피드백 문구(suggestions) 작성 시, 기술적인 JSON 키 경로(예: images.erd.description) 대신 반드시 아래의 **한글 항목명**을 사용하세요:
-                           - overview: 프로젝트 개요
-                           - roles: 담당 역할
-                           - tech: 기술 스택
-                           - features: 주요 기능
-                           - troubleshoots: 트러블슈팅
-                           - metrics: 성과 및 지표
-                           - architecture: 시스템 아키텍처
-                           - erd: 데이터베이스 ERD
-                           - ui: 주요 UI 화면
-                        3. "설명이 부족합니다", "구체적인 수치를 추가하세요"와 같이 사용자에게 직접적인 조언을 하는 말투를 사용하세요.
-                        4. 반드시 아래 구조의 **순수 JSON 포맷으로만** 답변해야 합니다. 마크다운 기호(```json)나 설명은 절대 포함하지 마세요.
-                        
-                        {
-                          "score": 0~100 사이의 정수 점수,
-                          "missingSections": ["부족한 섹션 영문 키 리스트"],
-                          "suggestions": ["사용자가 이해하기 쉬운 한글 피드백 문장 1", "한글 피드백 문장 2"],
-                          "autoCompletedFields": {
-                            "metrics": "AI가 제안하는 모범적인 성과 문장",
-                            "troubleshoots": [
-                              {
-                                "issue": "예상 문제",
-                                "resolution": "해결 방안"
-                              }
-                            ]
-                          }
-                        }
-                        """.formatted(requestJson);
+                                다음은 사용자가 입력 중인 포트폴리오 데이터입니다.
+
+                                [포트폴리오 데이터]
+                                %s
+
+                                [진단 가이드라인]
+                                1. 위 데이터를 기반으로 포트폴리오의 완성도를 진단하고 개선 사항을 도출하세요.
+                                2. 피드백 문구(suggestions) 작성 시, 기술적인 JSON 키 경로(예: images.erd.description) 대신 반드시 아래의 **한글 항목명**을 사용하세요:
+                                   - overview: 프로젝트 개요
+                                   - roles: 담당 역할/기여도
+                                   - projectPeriod: 프로젝트 기간
+                                   - teamSize: 팀 구성 및 인원
+                                   - primaryRole: 주요 직무
+                                   - tech: 기술 스택
+                                   - features: 주요 기능
+                                   - troubleshoots: 트러블슈팅
+                                   - metrics: 성과 및 지표
+                                   - architecture: 시스템 아키텍처
+                                   - erd: 데이터베이스 ERD
+                                   - ui: 주요 UI 화면
+                                3. "설명이 부족합니다", "구체적인 수치를 추가하세요"와 같이 사용자에게 직접적인 조언을 하는 말투를 사용하세요.
+                                4. 반드시 아래 구조의 **순수 JSON 포맷으로만** 답변해야 합니다. 마크다운 기호(```json)나 설명은 절대 포함하지 마세요.
+
+                                {
+                                  "score": 0~100 사이의 정수 점수,
+                                  "missingSections": ["부족한 섹션 영문 키 리스트"],
+                                  "suggestions": ["사용자가 이해하기 쉬운 한글 피드백 문장 1", "한글 피드백 문장 2"],
+                                  "autoCompletedFields": {
+                                    "metrics": "AI가 제안하는 모범적인 성과 문장",
+                                    "troubleshoots": [
+                                      {
+                                        "issue": "예상 문제",
+                                        "resolution": "해결 방안"
+                                      }
+                                    ]
+                                  }
+                                }
+                                """
+                                .formatted(requestJson);
         }
 }

--- a/devlog/src/main/java/com/devlog/devlog/auth/service/PortfolioService.java
+++ b/devlog/src/main/java/com/devlog/devlog/auth/service/PortfolioService.java
@@ -304,7 +304,7 @@ public class PortfolioService {
                 .shareUrl(shareUrl)
                 .build();
     }
-
+    @Transactional(readOnly = true)
     public SharedPortfolioResponse getSharePortfolio(String shareToken) {
         PortfolioEntity portfolioEntity = portfolioRepository.findByShareToken(shareToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_NOT_FOUND));
@@ -332,6 +332,9 @@ public class PortfolioService {
             return SharedPortfolioResponse.builder()
                     .id(portfolioEntity.getId())
                     .projectName(portfolioEntity.getProject().getTitle())
+                    .projectPeriod(portfolioEntity.getProjectPeriod())
+                    .teamSize(portfolioEntity.getTeamSize())
+                    .primaryRole(portfolioEntity.getPrimaryRole())
                     .overview(portfolioEntity.getOverview())
                     .roles(portfolioEntity.getRoles())
                     .techStack(techStack)

--- a/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
@@ -1,5 +1,6 @@
 package com.devlog.devlog.global.common;
 
+import com.devlog.devlog.global.exception.AiFeedbackLimitException;
 import com.devlog.devlog.global.exception.BusinessException;
 import com.devlog.devlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,18 @@ public class RateLimitService {
 
                 if (used != null && used > dailyLimit) {
                         redisTemplate.opsForValue().decrement(key);
+
+                        // AI 피드백 전용 예외 처리
+                        if (errorCode == ErrorCode.AI_FEEDBACK_DAILY_LIMIT_EXCEEDED) {
+                                throw new AiFeedbackLimitException(
+                                                UsageLimitResponse.builder()
+                                                                .dailyLimit(dailyLimit)
+                                                                .used(dailyLimit)
+                                                                .remaining(0)
+                                                                .resetAt(nextMidnight())
+                                                                .build());
+                        }
+
                         throw new BusinessException(errorCode);
                 }
 

--- a/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
@@ -18,7 +18,7 @@ public class RateLimitService {
 
         private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
-        public void validateLimit(
+        public UsageLimitResponse checkAndIncrement(
                         String prefix,
                         String userEmail,
                         int dailyLimit,
@@ -26,66 +26,45 @@ public class RateLimitService {
 
                 String key = prefix + userEmail;
 
-                String value = redisTemplate.opsForValue().get(key);
+                Long used = redisTemplate.opsForValue().increment(key);
 
-                int used = value == null
-                                ? 0
-                                : Integer.parseInt(value);
-
-                if (used >= dailyLimit) {
-
-                        throw new BusinessException(
-                                        errorCode);
+                if (used != null && used == 1L) {
+                        redisTemplate.expire(key, untilMidnight());
                 }
-        }
 
-        public UsageLimitResponse consume(
-                        String prefix,
-                        String userEmail,
-                        int dailyLimit) {
-
-                String key = prefix + userEmail;
-
-                Long count = redisTemplate.opsForValue()
-                                .increment(key);
-
-                if (count != null && count == 1L) {
-                        redisTemplate.expire(
-                                        key,
-                                        untilMidnight());
+                if (used != null && used > dailyLimit) {
+                        redisTemplate.opsForValue().decrement(key);
+                        throw new BusinessException(errorCode);
                 }
 
                 return UsageLimitResponse.builder()
                                 .dailyLimit(dailyLimit)
-                                .used(count.intValue())
-                                .remaining(
-                                                dailyLimit - count.intValue())
+                                .used(used.intValue())
+                                .remaining(dailyLimit - used.intValue())
                                 .resetAt(nextMidnight())
                                 .build();
         }
 
+        public void rollback(String prefix, String userEmail) {
+                String key = prefix + userEmail;
+                redisTemplate.opsForValue().decrement(key);
+        }
+
         public Duration untilMidnight() {
-
                 ZonedDateTime now = ZonedDateTime.now(ZONE_ID);
-
                 ZonedDateTime midnight = now.plusDays(1)
                                 .toLocalDate()
                                 .atStartOfDay(ZONE_ID);
 
-                return Duration.between(
-                                now,
-                                midnight);
+                return Duration.between(now, midnight);
         }
 
         public String nextMidnight() {
-
                 ZonedDateTime midnight = ZonedDateTime.now(ZONE_ID)
                                 .plusDays(1)
                                 .toLocalDate()
                                 .atStartOfDay(ZONE_ID);
 
-                return midnight.format(
-                                DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                return midnight.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         }
-
 }

--- a/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/common/RateLimitService.java
@@ -1,0 +1,91 @@
+package com.devlog.devlog.global.common;
+
+import com.devlog.devlog.global.exception.BusinessException;
+import com.devlog.devlog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class RateLimitService {
+        private final StringRedisTemplate redisTemplate;
+
+        private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+        public void validateLimit(
+                        String prefix,
+                        String userEmail,
+                        int dailyLimit,
+                        ErrorCode errorCode) {
+
+                String key = prefix + userEmail;
+
+                String value = redisTemplate.opsForValue().get(key);
+
+                int used = value == null
+                                ? 0
+                                : Integer.parseInt(value);
+
+                if (used >= dailyLimit) {
+
+                        throw new BusinessException(
+                                        errorCode);
+                }
+        }
+
+        public UsageLimitResponse consume(
+                        String prefix,
+                        String userEmail,
+                        int dailyLimit) {
+
+                String key = prefix + userEmail;
+
+                Long count = redisTemplate.opsForValue()
+                                .increment(key);
+
+                if (count != null && count == 1L) {
+                        redisTemplate.expire(
+                                        key,
+                                        untilMidnight());
+                }
+
+                return UsageLimitResponse.builder()
+                                .dailyLimit(dailyLimit)
+                                .used(count.intValue())
+                                .remaining(
+                                                dailyLimit - count.intValue())
+                                .resetAt(nextMidnight())
+                                .build();
+        }
+
+        public Duration untilMidnight() {
+
+                ZonedDateTime now = ZonedDateTime.now(ZONE_ID);
+
+                ZonedDateTime midnight = now.plusDays(1)
+                                .toLocalDate()
+                                .atStartOfDay(ZONE_ID);
+
+                return Duration.between(
+                                now,
+                                midnight);
+        }
+
+        public String nextMidnight() {
+
+                ZonedDateTime midnight = ZonedDateTime.now(ZONE_ID)
+                                .plusDays(1)
+                                .toLocalDate()
+                                .atStartOfDay(ZONE_ID);
+
+                return midnight.format(
+                                DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+
+}

--- a/devlog/src/main/java/com/devlog/devlog/global/common/UsageLimitResponse.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/common/UsageLimitResponse.java
@@ -1,0 +1,17 @@
+package com.devlog.devlog.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UsageLimitResponse {
+    private int dailyLimit;
+    private int used;
+    private int remaining;
+    private String resetAt;
+}

--- a/devlog/src/main/java/com/devlog/devlog/global/exception/AiFeedbackLimitException.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/exception/AiFeedbackLimitException.java
@@ -1,0 +1,13 @@
+package com.devlog.devlog.global.exception;
+
+import com.devlog.devlog.global.common.UsageLimitResponse;
+import lombok.Getter;
+
+@Getter
+public class AiFeedbackLimitException extends RuntimeException {
+    private final UsageLimitResponse usageLimitResponse;
+    public AiFeedbackLimitException(UsageLimitResponse usageLimitResponse) {
+        super("오늘 AI 개선 사용량을 모두 사용했습니다. 내일 다시 도전해주세요. ");
+        this.usageLimitResponse = usageLimitResponse;
+    }
+}

--- a/devlog/src/main/java/com/devlog/devlog/global/exception/ErrorCode.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     //Portfolio
     PORTFOLIO_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO-001", "포트폴리오를 찾을 수 없습니다."),
     UNAUTHORIZED_PORTFOLIO_ACCESS(HttpStatus.FORBIDDEN, "PORTFOLIO-002", "포트폴리오에 대한 권한이 없습니다."),
+    AI_FEEDBACK_DAILY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS,"PORTFOLIO-003","오늘 AI 개선 사용량을 모두 사용했습니다. 내일 다시 시도해 주세요."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK-001", "북마크를 찾을 수 없습니다."),

--- a/devlog/src/main/java/com/devlog/devlog/global/exception/GlobalExceptionHandler.java
+++ b/devlog/src/main/java/com/devlog/devlog/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -38,5 +39,22 @@ public class GlobalExceptionHandler {
                 return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
                                                 ErrorCode.INTERNAL_SERVER_ERROR.getCode()));
+        }
+
+        @ExceptionHandler(AiFeedbackLimitException.class)
+        protected ResponseEntity<ApiResponse<?>> handleAiLimit(
+                AiFeedbackLimitException e
+        ) {
+
+                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                        .body(
+                                ApiResponse.error(
+                                        "오늘 AI 개선 사용량을 모두 사용했습니다. 내일 다시 시도해 주세요.",
+                                        Map.of(
+                                                "usageLimit",
+                                                e.getUsageLimitResponse()
+                                        )
+                                )
+                        );
         }
 }


### PR DESCRIPTION
## Summary by Sourcery

AI 포트폴리오 피드백과 리포지토리 분석 API에 일별 레이트 리밋을 적용하고, 클라이언트에 사용량 메타데이터를 노출하며, 공유 포트폴리오 AI 피드백의 컨텍스트와 응답 필드를 확장했습니다.

New Features:
- 일별 API 사용량을 추적하기 위한 재사용 가능한 Redis 기반 레이트 리밋 서비스와 사용량 메타데이터 DTO를 추가했습니다.
- 포트폴리오 AI 피드백 엔드포인트에 사용자별 일일 요청 가능 횟수를 제한하고, 응답에 사용량 한도 정보를 포함했습니다.
- 더 풍부한 AI 컨텍스트를 위해 공유 포트폴리오 및 AI 피드백 요청/응답에 프로젝트 기간, 팀 규모, 주요 역할 필드를 확장했습니다.

Bug Fixes:
- 증가된 카운트에서 남은 쿼터를 계산하도록 Git 분석 레이트 리밋 로직을 수정하고, 만료 시간을 한 번만 초기화하도록 했습니다.

Enhancements:
- Gemini AI 피드백 프롬프트를 업데이트하여 추가 포트폴리오 메타데이터 필드를 포함하고, 한국어 피드백 라벨에 대한 가이던스를 개선했습니다.
- 공유 포트폴리오 조회를 읽기 전용 트랜잭션으로 표시하고, 공유 포트폴리오 API 응답 구조를 조정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce daily rate limiting for AI portfolio feedback and repository analysis APIs, expose usage metadata to clients, and enrich shared portfolio AI feedback context and response fields.

New Features:
- Add reusable Redis-backed rate limiting service and usage metadata DTO for tracking daily API usage.
- Limit portfolio AI feedback endpoint to a fixed number of daily requests per user and include usage limit information in responses.
- Extend shared portfolio and AI feedback requests/responses with project period, team size, and primary role fields for richer AI context.

Bug Fixes:
- Correct Git analysis rate limiting logic to initialize expiry once and compute remaining quota from the incremented count.

Enhancements:
- Update Gemini AI feedback prompt to cover additional portfolio metadata fields and refine guidance for Korean feedback labels.
- Mark shared portfolio retrieval as read-only transactional and adjust shared portfolio API response structure.

</details>